### PR TITLE
Doxygen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@
 .idea/
 .vscode/
 
+# doxygen folder
+doxys_documentation/
+
 # Build folders.
 # This rule ignores any folder in the project root that contains "build"
 /*build*/

--- a/cmake/modules/doxygen.cmake
+++ b/cmake/modules/doxygen.cmake
@@ -6,19 +6,14 @@ if (DOXYGEN_FOUND)
     # Create an option to turn on/off the generation of the documentation
     option(GENERATE_DOC "Generate documentation with Doxygen" ON)
     if (GENERATE_DOC)
-        # set input Doxyfile and output directory for the documentation
+        # set input Doxyfile
         set(DOXYGEN_CONFIG ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile)
-        set(DOCUMENTATION_OUT ${CMAKE_CURRENT_BINARY_DIR}/documentation)
-
-        # request to configure the file
-        # @ONLY will only replace variables of the form @VAR@
-        configure_file(${DOXYGEN_CONFIG} ${DOCUMENTATION_OUT} @ONLY)
 
         # add a target to generate the documentation
         # i.e. create documentation by make doc_doxygen
         add_custom_target(doc_doxygen
-                COMMAND ${DOXYGEN_EXECUTABLE} ${DOCUMENTATION_OUT}
-                WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+                COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYGEN_CONFIG}
+                WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} # Folder to use as root to discover the input files
                 COMMENT "Generating documentation with Doxygen"
                 VERBATIM)
     endif (GENERATE_DOC)

--- a/cmake/modules/doxygen.cmake
+++ b/cmake/modules/doxygen.cmake
@@ -1,5 +1,25 @@
-# make doc_doxygen optional if someone does not have / like doxygen
+# Check if Doxygen is installed
+find_package(Doxygen)
 
-# TODO: create CMake build option for the target.
+# Dont do anything if Doxygen is not installed
+if (DOXYGEN_FOUND)
+    # Create an option to turn on/off the generation of the documentation
+    option(GENERATE_DOC "Generate documentation with Doxygen" ON)
+    if (GENERATE_DOC)
+        # set input Doxyfile and output directory for the documentation
+        set(DOXYGEN_CONFIG ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile)
+        set(DOCUMENTATION_OUT ${CMAKE_CURRENT_BINARY_DIR}/documentation)
 
-# TODO: Add a custom target for building the documentation.
+        # request to configure the file
+        # @ONLY will only replace variables of the form @VAR@
+        configure_file(${DOXYGEN_CONFIG} ${DOCUMENTATION_OUT} @ONLY)
+
+        # add a target to generate the documentation
+        # i.e. create documentation by make doc_doxygen
+        add_custom_target(doc_doxygen
+                COMMAND ${DOXYGEN_EXECUTABLE} ${DOCUMENTATION_OUT}
+                WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+                COMMENT "Generating documentation with Doxygen"
+                VERBATIM)
+    endif (GENERATE_DOC)
+endif (DOXYGEN_FOUND)


### PR DESCRIPTION
Fix doxygen cmake. Wrong working dir was set i.e. no files were documented. Also simplified the code to remove unnecessary parts from the tutorial