### PR TITLE
Xmlparams

### DIFF
--- a/input/small_rayleigh_taylor.xml
+++ b/input/small_rayleigh_taylor.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<simulation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+  <params>
+    <delta_t>0.0005</delta_t>
+    <end_time>25</end_time>
+    <output>rl_small</output>
+    <frequency>10</frequency>
+    <!-- Domain params -->
+    <domainOrigin>
+      <x>0</x>
+      <y>0</y>
+      <z>0</z>
+    </domainOrigin>
+    <domainSize>
+      <x>63</x>
+      <y>36</y>
+      <z>0</z>
+    </domainSize>
+    <cutoff>2.5</cutoff>
+    <!-- Boundary params -->
+    <boundaries>
+      <bound_four>periodic</bound_four>
+      <bound_four>periodic</bound_four>
+      <bound_four>outflow</bound_four>
+      <bound_four>soft_reflective</bound_four>
+    </boundaries>
+    <!-- Thermostat params -->
+    <thermostat>
+        <initialTemp>40</initialTemp>
+        <thermoFreq>1000</thermoFreq>
+    </thermostat>
+    <!-- Gravity params -->
+    <gravity>-12.44</gravity>
+  </params>
+
+  <!-- Cluster specifications -->
+  <clusters>
+    <cuboid>
+      <pos>
+        <x>0.6</x>
+        <y>2</y>
+        <z>0</z>
+      </pos>
+      <vel>
+        <x>0</x>
+        <y>0</y>
+        <z>0</z>
+      </vel>
+      <dim>
+        <x>50</x>
+        <y>14</y>
+        <z>1</z>
+      </dim>
+      <mass>1.0</mass>
+      <spacing>1.2</spacing>
+      <brownVel>1</brownVel>
+      <brownDim>2</brownDim>
+      <ptype>1</ptype>
+    </cuboid> 
+    <cuboid>
+      <pos>
+        <x>0.6</x>
+        <y>19</y>
+        <z>0</z>
+      </pos>
+      <vel>
+        <x>0</x>
+        <y>0</y>
+        <z>0</z>
+      </vel>
+      <dim>
+        <x>50</x>
+        <y>14</y>
+        <z>1</z>
+      </dim>
+      <mass>2.0</mass>
+      <spacing>1.2</spacing>
+      <brownVel>1</brownVel>
+      <brownDim>2</brownDim>
+      <ptype>2</ptype>
+    </cuboid>
+  </clusters>
+
+  <!-- Particle types -->
+  <ptypes>
+      <ptype type="1">
+          <sigma>1.0</sigma>
+          <epsilon>1.0</epsilon>
+      </ptype>
+      <ptype type="2">
+          <sigma>1.2</sigma>
+          <epsilon>1.0</epsilon>
+      </ptype>
+  </ptypes>
+</simulation>

--- a/src/io/fileReader/xmlReader.cpp
+++ b/src/io/fileReader/xmlReader.cpp
@@ -25,6 +25,10 @@ void XmlReader::readFile(Simulation& sim)
         // read cuboids
         const auto& cuboids = sim_input->clusters().cuboid();
         for (auto cuboid : cuboids) {
+            unsigned ptype = 0;
+            if (cuboid.ptype().present())
+                ptype = cuboid.ptype().get();
+            // read cuboid
             generator.registerCluster(std::make_unique<CuboidParticleCluster>(CuboidParticleCluster(
                 { cuboid.pos().x(), cuboid.pos().y(), cuboid.pos().z() },
                 cuboid.dim().x(),
@@ -34,12 +38,16 @@ void XmlReader::readFile(Simulation& sim)
                 cuboid.mass(),
                 { cuboid.vel().x(), cuboid.vel().y(), cuboid.vel().z() },
                 cuboid.brownVel(),
-                cuboid.brownDim())));
+                cuboid.brownDim(),
+                ptype)));
         }
 
         // read spheres
         const auto& spheres = sim_input->clusters().sphere();
         for (auto sphere : spheres) {
+            unsigned ptype = 0;
+            if (sphere.ptype().present())
+                ptype = sphere.ptype().get();
             // read sphere
             generator.registerCluster(std::make_unique<SphereParticleCluster>(SphereParticleCluster(
                 { sphere.center().x(), sphere.center().y(), sphere.center().z() },
@@ -49,7 +57,8 @@ void XmlReader::readFile(Simulation& sim)
                 sphere.mass(),
                 { sphere.vel().x(), sphere.vel().y(), sphere.vel().z() },
                 sphere.brownVel(),
-                sphere.brownDim())));
+                sphere.brownDim(),
+                ptype)));
         }
 
         generator.generateClusters();

--- a/src/io/fileWriter/XMLWriter.cpp
+++ b/src/io/fileWriter/XMLWriter.cpp
@@ -89,6 +89,9 @@ void XmlWriter::plotParticles(const Simulation& s)
         spdlog::debug("When writing to XML, not a LennardJonesDomainSimulation");
     }
 
+    // TODO: Write thermostat
+    // TODO: Write gravity
+
     // Initialize particle data
     DecimalArray_t points = DecimalArray_t(3);
     DecimalArray_t vels = DecimalArray_t(3);
@@ -98,7 +101,7 @@ void XmlWriter::plotParticles(const Simulation& s)
     DecimalArray_t type = DecimalArray_t(1);
 
     // Fill particle data
-    for (auto& p: s.container){
+    for (auto& p : s.container) {
         points.push_back(p.getX().at(0));
         points.push_back(p.getX().at(1));
         points.push_back(p.getX().at(2));
@@ -120,8 +123,10 @@ void XmlWriter::plotParticles(const Simulation& s)
 
     // Initialize final simulation object
     std::unique_ptr<clusters_t> clusters = std::make_unique<clusters_t>();
+    std::unique_ptr<ParticleTypes_t> ptypes = std::make_unique<ParticleTypes_t>();
     std::unique_ptr<simulation_t> sim =
         std::make_unique<simulation_t>(std::move(params), std::move(clusters));
+    sim->ptypes(std::move(ptypes));
     sim->particles(parts);
 
     // Initialize output file

--- a/src/io/xmlparse/xmlparse.cpp
+++ b/src/io/xmlparse/xmlparse.cpp
@@ -45,6 +45,8 @@ void xmlparse(Params& sim_params, std::string& filename)
             sim_params.output_file = params.output().get();
         if (params.updateFreq().present())
             sim_params.update_frequency = params.updateFreq().get();
+        if (params.gravity().present())
+            sim_params.gravity = params.gravity().get();
         if (params.boundaries().present()) {
             if (params.boundaries().get().bound_four().size()) {
                 sim_params.boundaryConfig = BoundaryConfig(
@@ -61,6 +63,34 @@ void xmlparse(Params& sim_params, std::string& filename)
                     getBoundaryType(params.boundaries().get().bound_six()[3]),
                     getBoundaryType(params.boundaries().get().bound_six()[4]),
                     getBoundaryType(params.boundaries().get().bound_six()[5]));
+            }
+        }
+        if (params.thermostat().present()) {
+            auto thermo_config = params.thermostat().get();
+            if (thermo_config.initialTemp().present())
+                sim_params.init_temp = thermo_config.initialTemp().get();
+            if (thermo_config.targetTemp().present())
+                sim_params.target_temp = thermo_config.targetTemp().get();
+            if (thermo_config.thermoFreq().present())
+                sim_params.thermo_freq = thermo_config.thermoFreq().get();
+            if (thermo_config.maxTempDelta().present())
+                sim_params.max_temp_delta = thermo_config.maxTempDelta().get();
+        }
+
+        // read particle types
+        if (sim_input->ptypes().present()) {
+            auto ptypes = sim_input->ptypes().get();
+            for (auto& type : ptypes.ptype()) {
+                unsigned typeID = type.type();
+                double epsilon = type.epsilon();
+                double sigma = type.sigma();
+                if(!typeID){
+                    spdlog::error("Particle type ID 0 is reserved, please choose another.");
+                    exit(EXIT_FAILURE);
+                }
+                sim_params.particleTypes.push_back({ epsilon, sigma });
+                sim_params.typesMap[typeID] = { epsilon, sigma };
+                spdlog::info("Registered particle type {}: sigma = {}, epsilon = {}", typeID, sigma, epsilon);
             }
         }
 

--- a/src/io/xsd/simulation.cpp
+++ b/src/io/xsd/simulation.cpp
@@ -245,6 +245,106 @@ bound_six (const bound_six_sequence& s)
 }
 
 
+// tempParams_t
+//
+
+const tempParams_t::initialTemp_optional& tempParams_t::
+initialTemp () const
+{
+  return this->initialTemp_;
+}
+
+tempParams_t::initialTemp_optional& tempParams_t::
+initialTemp ()
+{
+  return this->initialTemp_;
+}
+
+void tempParams_t::
+initialTemp (const initialTemp_type& x)
+{
+  this->initialTemp_.set (x);
+}
+
+void tempParams_t::
+initialTemp (const initialTemp_optional& x)
+{
+  this->initialTemp_ = x;
+}
+
+const tempParams_t::targetTemp_optional& tempParams_t::
+targetTemp () const
+{
+  return this->targetTemp_;
+}
+
+tempParams_t::targetTemp_optional& tempParams_t::
+targetTemp ()
+{
+  return this->targetTemp_;
+}
+
+void tempParams_t::
+targetTemp (const targetTemp_type& x)
+{
+  this->targetTemp_.set (x);
+}
+
+void tempParams_t::
+targetTemp (const targetTemp_optional& x)
+{
+  this->targetTemp_ = x;
+}
+
+const tempParams_t::thermoFreq_optional& tempParams_t::
+thermoFreq () const
+{
+  return this->thermoFreq_;
+}
+
+tempParams_t::thermoFreq_optional& tempParams_t::
+thermoFreq ()
+{
+  return this->thermoFreq_;
+}
+
+void tempParams_t::
+thermoFreq (const thermoFreq_type& x)
+{
+  this->thermoFreq_.set (x);
+}
+
+void tempParams_t::
+thermoFreq (const thermoFreq_optional& x)
+{
+  this->thermoFreq_ = x;
+}
+
+const tempParams_t::maxTempDelta_optional& tempParams_t::
+maxTempDelta () const
+{
+  return this->maxTempDelta_;
+}
+
+tempParams_t::maxTempDelta_optional& tempParams_t::
+maxTempDelta ()
+{
+  return this->maxTempDelta_;
+}
+
+void tempParams_t::
+maxTempDelta (const maxTempDelta_type& x)
+{
+  this->maxTempDelta_.set (x);
+}
+
+void tempParams_t::
+maxTempDelta (const maxTempDelta_optional& x)
+{
+  this->maxTempDelta_ = x;
+}
+
+
 // DecimalList_t
 //
 
@@ -445,6 +545,90 @@ TypeData (::std::unique_ptr< TypeData_type > x)
 }
 
 
+// ParticleType_t
+//
+
+const ParticleType_t::sigma_type& ParticleType_t::
+sigma () const
+{
+  return this->sigma_.get ();
+}
+
+ParticleType_t::sigma_type& ParticleType_t::
+sigma ()
+{
+  return this->sigma_.get ();
+}
+
+void ParticleType_t::
+sigma (const sigma_type& x)
+{
+  this->sigma_.set (x);
+}
+
+const ParticleType_t::epsilon_type& ParticleType_t::
+epsilon () const
+{
+  return this->epsilon_.get ();
+}
+
+ParticleType_t::epsilon_type& ParticleType_t::
+epsilon ()
+{
+  return this->epsilon_.get ();
+}
+
+void ParticleType_t::
+epsilon (const epsilon_type& x)
+{
+  this->epsilon_.set (x);
+}
+
+
+// ParticleTypeAttr_t
+//
+
+const ParticleTypeAttr_t::type_type& ParticleTypeAttr_t::
+type () const
+{
+  return this->type_.get ();
+}
+
+ParticleTypeAttr_t::type_type& ParticleTypeAttr_t::
+type ()
+{
+  return this->type_.get ();
+}
+
+void ParticleTypeAttr_t::
+type (const type_type& x)
+{
+  this->type_.set (x);
+}
+
+
+// ParticleTypes_t
+//
+
+const ParticleTypes_t::ptype_sequence& ParticleTypes_t::
+ptype () const
+{
+  return this->ptype_;
+}
+
+ParticleTypes_t::ptype_sequence& ParticleTypes_t::
+ptype ()
+{
+  return this->ptype_;
+}
+
+void ParticleTypes_t::
+ptype (const ptype_sequence& s)
+{
+  this->ptype_ = s;
+}
+
+
 // cuboid_t
 //
 
@@ -596,6 +780,30 @@ void cuboid_t::
 brownDim (::std::unique_ptr< brownDim_type > x)
 {
   this->brownDim_.set (std::move (x));
+}
+
+const cuboid_t::ptype_optional& cuboid_t::
+ptype () const
+{
+  return this->ptype_;
+}
+
+cuboid_t::ptype_optional& cuboid_t::
+ptype ()
+{
+  return this->ptype_;
+}
+
+void cuboid_t::
+ptype (const ptype_type& x)
+{
+  this->ptype_.set (x);
+}
+
+void cuboid_t::
+ptype (const ptype_optional& x)
+{
+  this->ptype_ = x;
 }
 
 
@@ -768,6 +976,30 @@ void sphere_t::
 brownDim (::std::unique_ptr< brownDim_type > x)
 {
   this->brownDim_.set (std::move (x));
+}
+
+const sphere_t::ptype_optional& sphere_t::
+ptype () const
+{
+  return this->ptype_;
+}
+
+sphere_t::ptype_optional& sphere_t::
+ptype ()
+{
+  return this->ptype_;
+}
+
+void sphere_t::
+ptype (const ptype_type& x)
+{
+  this->ptype_.set (x);
+}
+
+void sphere_t::
+ptype (const ptype_optional& x)
+{
+  this->ptype_ = x;
 }
 
 
@@ -1126,6 +1358,60 @@ boundaries (::std::unique_ptr< boundaries_type > x)
   this->boundaries_.set (std::move (x));
 }
 
+const params_t::thermostat_optional& params_t::
+thermostat () const
+{
+  return this->thermostat_;
+}
+
+params_t::thermostat_optional& params_t::
+thermostat ()
+{
+  return this->thermostat_;
+}
+
+void params_t::
+thermostat (const thermostat_type& x)
+{
+  this->thermostat_.set (x);
+}
+
+void params_t::
+thermostat (const thermostat_optional& x)
+{
+  this->thermostat_ = x;
+}
+
+void params_t::
+thermostat (::std::unique_ptr< thermostat_type > x)
+{
+  this->thermostat_.set (std::move (x));
+}
+
+const params_t::gravity_optional& params_t::
+gravity () const
+{
+  return this->gravity_;
+}
+
+params_t::gravity_optional& params_t::
+gravity ()
+{
+  return this->gravity_;
+}
+
+void params_t::
+gravity (const gravity_type& x)
+{
+  this->gravity_.set (x);
+}
+
+void params_t::
+gravity (const gravity_optional& x)
+{
+  this->gravity_ = x;
+}
+
 
 // simulation_t
 //
@@ -1176,6 +1462,36 @@ void simulation_t::
 clusters (::std::unique_ptr< clusters_type > x)
 {
   this->clusters_.set (std::move (x));
+}
+
+const simulation_t::ptypes_optional& simulation_t::
+ptypes () const
+{
+  return this->ptypes_;
+}
+
+simulation_t::ptypes_optional& simulation_t::
+ptypes ()
+{
+  return this->ptypes_;
+}
+
+void simulation_t::
+ptypes (const ptypes_type& x)
+{
+  this->ptypes_.set (x);
+}
+
+void simulation_t::
+ptypes (const ptypes_optional& x)
+{
+  this->ptypes_ = x;
+}
+
+void simulation_t::
+ptypes (::std::unique_ptr< ptypes_type > x)
+{
+  this->ptypes_.set (std::move (x));
 }
 
 const simulation_t::particles_optional& simulation_t::
@@ -1704,6 +2020,133 @@ boundary_t::
 {
 }
 
+// tempParams_t
+//
+
+tempParams_t::
+tempParams_t ()
+: ::xml_schema::type (),
+  initialTemp_ (this),
+  targetTemp_ (this),
+  thermoFreq_ (this),
+  maxTempDelta_ (this)
+{
+}
+
+tempParams_t::
+tempParams_t (const tempParams_t& x,
+              ::xml_schema::flags f,
+              ::xml_schema::container* c)
+: ::xml_schema::type (x, f, c),
+  initialTemp_ (x.initialTemp_, f, this),
+  targetTemp_ (x.targetTemp_, f, this),
+  thermoFreq_ (x.thermoFreq_, f, this),
+  maxTempDelta_ (x.maxTempDelta_, f, this)
+{
+}
+
+tempParams_t::
+tempParams_t (const ::xercesc::DOMElement& e,
+              ::xml_schema::flags f,
+              ::xml_schema::container* c)
+: ::xml_schema::type (e, f | ::xml_schema::flags::base, c),
+  initialTemp_ (this),
+  targetTemp_ (this),
+  thermoFreq_ (this),
+  maxTempDelta_ (this)
+{
+  if ((f & ::xml_schema::flags::base) == 0)
+  {
+    ::xsd::cxx::xml::dom::parser< char > p (e, true, false, false);
+    this->parse (p, f);
+  }
+}
+
+void tempParams_t::
+parse (::xsd::cxx::xml::dom::parser< char >& p,
+       ::xml_schema::flags f)
+{
+  for (; p.more_content (); p.next_content (false))
+  {
+    const ::xercesc::DOMElement& i (p.cur_element ());
+    const ::xsd::cxx::xml::qualified_name< char > n (
+      ::xsd::cxx::xml::dom::name< char > (i));
+
+    // initialTemp
+    //
+    if (n.name () == "initialTemp" && n.namespace_ ().empty ())
+    {
+      if (!this->initialTemp_)
+      {
+        this->initialTemp_.set (initialTemp_traits::create (i, f, this));
+        continue;
+      }
+    }
+
+    // targetTemp
+    //
+    if (n.name () == "targetTemp" && n.namespace_ ().empty ())
+    {
+      if (!this->targetTemp_)
+      {
+        this->targetTemp_.set (targetTemp_traits::create (i, f, this));
+        continue;
+      }
+    }
+
+    // thermoFreq
+    //
+    if (n.name () == "thermoFreq" && n.namespace_ ().empty ())
+    {
+      if (!this->thermoFreq_)
+      {
+        this->thermoFreq_.set (thermoFreq_traits::create (i, f, this));
+        continue;
+      }
+    }
+
+    // maxTempDelta
+    //
+    if (n.name () == "maxTempDelta" && n.namespace_ ().empty ())
+    {
+      if (!this->maxTempDelta_)
+      {
+        this->maxTempDelta_.set (maxTempDelta_traits::create (i, f, this));
+        continue;
+      }
+    }
+
+    break;
+  }
+}
+
+tempParams_t* tempParams_t::
+_clone (::xml_schema::flags f,
+        ::xml_schema::container* c) const
+{
+  return new class tempParams_t (*this, f, c);
+}
+
+tempParams_t& tempParams_t::
+operator= (const tempParams_t& x)
+{
+  if (this != &x)
+  {
+    static_cast< ::xml_schema::type& > (*this) = x;
+    this->initialTemp_ = x.initialTemp_;
+    this->targetTemp_ = x.targetTemp_;
+    this->thermoFreq_ = x.thermoFreq_;
+    this->maxTempDelta_ = x.maxTempDelta_;
+  }
+
+  return *this;
+}
+
+tempParams_t::
+~tempParams_t ()
+{
+}
+
 // DecimalList_t
 //
 
@@ -2076,6 +2519,287 @@ ParticleData_t::
 {
 }
 
+// ParticleType_t
+//
+
+ParticleType_t::
+ParticleType_t (const sigma_type& sigma,
+                const epsilon_type& epsilon)
+: ::xml_schema::type (),
+  sigma_ (sigma, this),
+  epsilon_ (epsilon, this)
+{
+}
+
+ParticleType_t::
+ParticleType_t (const ParticleType_t& x,
+                ::xml_schema::flags f,
+                ::xml_schema::container* c)
+: ::xml_schema::type (x, f, c),
+  sigma_ (x.sigma_, f, this),
+  epsilon_ (x.epsilon_, f, this)
+{
+}
+
+ParticleType_t::
+ParticleType_t (const ::xercesc::DOMElement& e,
+                ::xml_schema::flags f,
+                ::xml_schema::container* c)
+: ::xml_schema::type (e, f | ::xml_schema::flags::base, c),
+  sigma_ (this),
+  epsilon_ (this)
+{
+  if ((f & ::xml_schema::flags::base) == 0)
+  {
+    ::xsd::cxx::xml::dom::parser< char > p (e, true, false, false);
+    this->parse (p, f);
+  }
+}
+
+void ParticleType_t::
+parse (::xsd::cxx::xml::dom::parser< char >& p,
+       ::xml_schema::flags f)
+{
+  for (; p.more_content (); p.next_content (false))
+  {
+    const ::xercesc::DOMElement& i (p.cur_element ());
+    const ::xsd::cxx::xml::qualified_name< char > n (
+      ::xsd::cxx::xml::dom::name< char > (i));
+
+    // sigma
+    //
+    if (n.name () == "sigma" && n.namespace_ ().empty ())
+    {
+      if (!sigma_.present ())
+      {
+        this->sigma_.set (sigma_traits::create (i, f, this));
+        continue;
+      }
+    }
+
+    // epsilon
+    //
+    if (n.name () == "epsilon" && n.namespace_ ().empty ())
+    {
+      if (!epsilon_.present ())
+      {
+        this->epsilon_.set (epsilon_traits::create (i, f, this));
+        continue;
+      }
+    }
+
+    break;
+  }
+
+  if (!sigma_.present ())
+  {
+    throw ::xsd::cxx::tree::expected_element< char > (
+      "sigma",
+      "");
+  }
+
+  if (!epsilon_.present ())
+  {
+    throw ::xsd::cxx::tree::expected_element< char > (
+      "epsilon",
+      "");
+  }
+}
+
+ParticleType_t* ParticleType_t::
+_clone (::xml_schema::flags f,
+        ::xml_schema::container* c) const
+{
+  return new class ParticleType_t (*this, f, c);
+}
+
+ParticleType_t& ParticleType_t::
+operator= (const ParticleType_t& x)
+{
+  if (this != &x)
+  {
+    static_cast< ::xml_schema::type& > (*this) = x;
+    this->sigma_ = x.sigma_;
+    this->epsilon_ = x.epsilon_;
+  }
+
+  return *this;
+}
+
+ParticleType_t::
+~ParticleType_t ()
+{
+}
+
+// ParticleTypeAttr_t
+//
+
+ParticleTypeAttr_t::
+ParticleTypeAttr_t (const sigma_type& sigma,
+                    const epsilon_type& epsilon,
+                    const type_type& type)
+: ::ParticleType_t (sigma,
+                    epsilon),
+  type_ (type, this)
+{
+}
+
+ParticleTypeAttr_t::
+ParticleTypeAttr_t (const ParticleTypeAttr_t& x,
+                    ::xml_schema::flags f,
+                    ::xml_schema::container* c)
+: ::ParticleType_t (x, f, c),
+  type_ (x.type_, f, this)
+{
+}
+
+ParticleTypeAttr_t::
+ParticleTypeAttr_t (const ::xercesc::DOMElement& e,
+                    ::xml_schema::flags f,
+                    ::xml_schema::container* c)
+: ::ParticleType_t (e, f | ::xml_schema::flags::base, c),
+  type_ (this)
+{
+  if ((f & ::xml_schema::flags::base) == 0)
+  {
+    ::xsd::cxx::xml::dom::parser< char > p (e, true, false, true);
+    this->parse (p, f);
+  }
+}
+
+void ParticleTypeAttr_t::
+parse (::xsd::cxx::xml::dom::parser< char >& p,
+       ::xml_schema::flags f)
+{
+  this->::ParticleType_t::parse (p, f);
+
+  while (p.more_attributes ())
+  {
+    const ::xercesc::DOMAttr& i (p.next_attribute ());
+    const ::xsd::cxx::xml::qualified_name< char > n (
+      ::xsd::cxx::xml::dom::name< char > (i));
+
+    if (n.name () == "type" && n.namespace_ ().empty ())
+    {
+      this->type_.set (type_traits::create (i, f, this));
+      continue;
+    }
+  }
+
+  if (!type_.present ())
+  {
+    throw ::xsd::cxx::tree::expected_attribute< char > (
+      "type",
+      "");
+  }
+}
+
+ParticleTypeAttr_t* ParticleTypeAttr_t::
+_clone (::xml_schema::flags f,
+        ::xml_schema::container* c) const
+{
+  return new class ParticleTypeAttr_t (*this, f, c);
+}
+
+ParticleTypeAttr_t& ParticleTypeAttr_t::
+operator= (const ParticleTypeAttr_t& x)
+{
+  if (this != &x)
+  {
+    static_cast< ::ParticleType_t& > (*this) = x;
+    this->type_ = x.type_;
+  }
+
+  return *this;
+}
+
+ParticleTypeAttr_t::
+~ParticleTypeAttr_t ()
+{
+}
+
+// ParticleTypes_t
+//
+
+ParticleTypes_t::
+ParticleTypes_t ()
+: ::xml_schema::type (),
+  ptype_ (this)
+{
+}
+
+ParticleTypes_t::
+ParticleTypes_t (const ParticleTypes_t& x,
+                 ::xml_schema::flags f,
+                 ::xml_schema::container* c)
+: ::xml_schema::type (x, f, c),
+  ptype_ (x.ptype_, f, this)
+{
+}
+
+ParticleTypes_t::
+ParticleTypes_t (const ::xercesc::DOMElement& e,
+                 ::xml_schema::flags f,
+                 ::xml_schema::container* c)
+: ::xml_schema::type (e, f | ::xml_schema::flags::base, c),
+  ptype_ (this)
+{
+  if ((f & ::xml_schema::flags::base) == 0)
+  {
+    ::xsd::cxx::xml::dom::parser< char > p (e, true, false, false);
+    this->parse (p, f);
+  }
+}
+
+void ParticleTypes_t::
+parse (::xsd::cxx::xml::dom::parser< char >& p,
+       ::xml_schema::flags f)
+{
+  for (; p.more_content (); p.next_content (false))
+  {
+    const ::xercesc::DOMElement& i (p.cur_element ());
+    const ::xsd::cxx::xml::qualified_name< char > n (
+      ::xsd::cxx::xml::dom::name< char > (i));
+
+    // ptype
+    //
+    if (n.name () == "ptype" && n.namespace_ ().empty ())
+    {
+      ::std::unique_ptr< ptype_type > r (
+        ptype_traits::create (i, f, this));
+
+      this->ptype_.push_back (::std::move (r));
+      continue;
+    }
+
+    break;
+  }
+}
+
+ParticleTypes_t* ParticleTypes_t::
+_clone (::xml_schema::flags f,
+        ::xml_schema::container* c) const
+{
+  return new class ParticleTypes_t (*this, f, c);
+}
+
+ParticleTypes_t& ParticleTypes_t::
+operator= (const ParticleTypes_t& x)
+{
+  if (this != &x)
+  {
+    static_cast< ::xml_schema::type& > (*this) = x;
+    this->ptype_ = x.ptype_;
+  }
+
+  return *this;
+}
+
+ParticleTypes_t::
+~ParticleTypes_t ()
+{
+}
+
 // cuboid_t
 //
 
@@ -2094,7 +2818,8 @@ cuboid_t (const pos_type& pos,
   mass_ (mass, this),
   spacing_ (spacing, this),
   brownVel_ (brownVel, this),
-  brownDim_ (brownDim, this)
+  brownDim_ (brownDim, this),
+  ptype_ (this)
 {
 }
 
@@ -2113,7 +2838,8 @@ cuboid_t (::std::unique_ptr< pos_type > pos,
   mass_ (mass, this),
   spacing_ (spacing, this),
   brownVel_ (brownVel, this),
-  brownDim_ (brownDim, this)
+  brownDim_ (brownDim, this),
+  ptype_ (this)
 {
 }
 
@@ -2128,7 +2854,8 @@ cuboid_t (const cuboid_t& x,
   mass_ (x.mass_, f, this),
   spacing_ (x.spacing_, f, this),
   brownVel_ (x.brownVel_, f, this),
-  brownDim_ (x.brownDim_, f, this)
+  brownDim_ (x.brownDim_, f, this),
+  ptype_ (x.ptype_, f, this)
 {
 }
 
@@ -2143,7 +2870,8 @@ cuboid_t (const ::xercesc::DOMElement& e,
   mass_ (this),
   spacing_ (this),
   brownVel_ (this),
-  brownDim_ (this)
+  brownDim_ (this),
+  ptype_ (this)
 {
   if ((f & ::xml_schema::flags::base) == 0)
   {
@@ -2251,6 +2979,17 @@ parse (::xsd::cxx::xml::dom::parser< char >& p,
       }
     }
 
+    // ptype
+    //
+    if (n.name () == "ptype" && n.namespace_ ().empty ())
+    {
+      if (!this->ptype_)
+      {
+        this->ptype_.set (ptype_traits::create (i, f, this));
+        continue;
+      }
+    }
+
     break;
   }
 
@@ -2324,6 +3063,7 @@ operator= (const cuboid_t& x)
     this->spacing_ = x.spacing_;
     this->brownVel_ = x.brownVel_;
     this->brownDim_ = x.brownDim_;
+    this->ptype_ = x.ptype_;
   }
 
   return *this;
@@ -2354,7 +3094,8 @@ sphere_t (const center_type& center,
   sphereDim_ (sphereDim, this),
   spacing_ (spacing, this),
   brownVel_ (brownVel, this),
-  brownDim_ (brownDim, this)
+  brownDim_ (brownDim, this),
+  ptype_ (this)
 {
 }
 
@@ -2375,7 +3116,8 @@ sphere_t (::std::unique_ptr< center_type > center,
   sphereDim_ (sphereDim, this),
   spacing_ (spacing, this),
   brownVel_ (brownVel, this),
-  brownDim_ (brownDim, this)
+  brownDim_ (brownDim, this),
+  ptype_ (this)
 {
 }
 
@@ -2391,7 +3133,8 @@ sphere_t (const sphere_t& x,
   sphereDim_ (x.sphereDim_, f, this),
   spacing_ (x.spacing_, f, this),
   brownVel_ (x.brownVel_, f, this),
-  brownDim_ (x.brownDim_, f, this)
+  brownDim_ (x.brownDim_, f, this),
+  ptype_ (x.ptype_, f, this)
 {
 }
 
@@ -2407,7 +3150,8 @@ sphere_t (const ::xercesc::DOMElement& e,
   sphereDim_ (this),
   spacing_ (this),
   brownVel_ (this),
-  brownDim_ (this)
+  brownDim_ (this),
+  ptype_ (this)
 {
   if ((f & ::xml_schema::flags::base) == 0)
   {
@@ -2526,6 +3270,17 @@ parse (::xsd::cxx::xml::dom::parser< char >& p,
       }
     }
 
+    // ptype
+    //
+    if (n.name () == "ptype" && n.namespace_ ().empty ())
+    {
+      if (!this->ptype_)
+      {
+        this->ptype_.set (ptype_traits::create (i, f, this));
+        continue;
+      }
+    }
+
     break;
   }
 
@@ -2607,6 +3362,7 @@ operator= (const sphere_t& x)
     this->spacing_ = x.spacing_;
     this->brownVel_ = x.brownVel_;
     this->brownDim_ = x.brownDim_;
+    this->ptype_ = x.ptype_;
   }
 
   return *this;
@@ -2731,7 +3487,9 @@ params_t ()
   domainSize_ (this),
   cutoff_ (this),
   updateFreq_ (this),
-  boundaries_ (this)
+  boundaries_ (this),
+  thermostat_ (this),
+  gravity_ (this)
 {
 }
 
@@ -2751,7 +3509,9 @@ params_t (const params_t& x,
   domainSize_ (x.domainSize_, f, this),
   cutoff_ (x.cutoff_, f, this),
   updateFreq_ (x.updateFreq_, f, this),
-  boundaries_ (x.boundaries_, f, this)
+  boundaries_ (x.boundaries_, f, this),
+  thermostat_ (x.thermostat_, f, this),
+  gravity_ (x.gravity_, f, this)
 {
 }
 
@@ -2771,7 +3531,9 @@ params_t (const ::xercesc::DOMElement& e,
   domainSize_ (this),
   cutoff_ (this),
   updateFreq_ (this),
-  boundaries_ (this)
+  boundaries_ (this),
+  thermostat_ (this),
+  gravity_ (this)
 {
   if ((f & ::xml_schema::flags::base) == 0)
   {
@@ -2934,6 +3696,31 @@ parse (::xsd::cxx::xml::dom::parser< char >& p,
       }
     }
 
+    // thermostat
+    //
+    if (n.name () == "thermostat" && n.namespace_ ().empty ())
+    {
+      ::std::unique_ptr< thermostat_type > r (
+        thermostat_traits::create (i, f, this));
+
+      if (!this->thermostat_)
+      {
+        this->thermostat_.set (::std::move (r));
+        continue;
+      }
+    }
+
+    // gravity
+    //
+    if (n.name () == "gravity" && n.namespace_ ().empty ())
+    {
+      if (!this->gravity_)
+      {
+        this->gravity_.set (gravity_traits::create (i, f, this));
+        continue;
+      }
+    }
+
     break;
   }
 }
@@ -2963,6 +3750,8 @@ operator= (const params_t& x)
     this->cutoff_ = x.cutoff_;
     this->updateFreq_ = x.updateFreq_;
     this->boundaries_ = x.boundaries_;
+    this->thermostat_ = x.thermostat_;
+    this->gravity_ = x.gravity_;
   }
 
   return *this;
@@ -2982,6 +3771,7 @@ simulation_t (const params_type& params,
 : ::xml_schema::type (),
   params_ (params, this),
   clusters_ (clusters, this),
+  ptypes_ (this),
   particles_ (this)
 {
 }
@@ -2992,6 +3782,7 @@ simulation_t (::std::unique_ptr< params_type > params,
 : ::xml_schema::type (),
   params_ (std::move (params), this),
   clusters_ (std::move (clusters), this),
+  ptypes_ (this),
   particles_ (this)
 {
 }
@@ -3003,6 +3794,7 @@ simulation_t (const simulation_t& x,
 : ::xml_schema::type (x, f, c),
   params_ (x.params_, f, this),
   clusters_ (x.clusters_, f, this),
+  ptypes_ (x.ptypes_, f, this),
   particles_ (x.particles_, f, this)
 {
 }
@@ -3014,6 +3806,7 @@ simulation_t (const ::xercesc::DOMElement& e,
 : ::xml_schema::type (e, f | ::xml_schema::flags::base, c),
   params_ (this),
   clusters_ (this),
+  ptypes_ (this),
   particles_ (this)
 {
   if ((f & ::xml_schema::flags::base) == 0)
@@ -3057,6 +3850,20 @@ parse (::xsd::cxx::xml::dom::parser< char >& p,
       if (!clusters_.present ())
       {
         this->clusters_.set (::std::move (r));
+        continue;
+      }
+    }
+
+    // ptypes
+    //
+    if (n.name () == "ptypes" && n.namespace_ ().empty ())
+    {
+      ::std::unique_ptr< ptypes_type > r (
+        ptypes_traits::create (i, f, this));
+
+      if (!this->ptypes_)
+      {
+        this->ptypes_.set (::std::move (r));
         continue;
       }
     }
@@ -3108,6 +3915,7 @@ operator= (const simulation_t& x)
     static_cast< ::xml_schema::type& > (*this) = x;
     this->params_ = x.params_;
     this->clusters_ = x.clusters_;
+    this->ptypes_ = x.ptypes_;
     this->particles_ = x.particles_;
   }
 
@@ -3548,6 +4356,60 @@ operator<< (::xercesc::DOMElement& e, const boundary_t& i)
 }
 
 void
+operator<< (::xercesc::DOMElement& e, const tempParams_t& i)
+{
+  e << static_cast< const ::xml_schema::type& > (i);
+
+  // initialTemp
+  //
+  if (i.initialTemp ())
+  {
+    ::xercesc::DOMElement& s (
+      ::xsd::cxx::xml::dom::create_element (
+        "initialTemp",
+        e));
+
+    s << ::xml_schema::as_double(*i.initialTemp ());
+  }
+
+  // targetTemp
+  //
+  if (i.targetTemp ())
+  {
+    ::xercesc::DOMElement& s (
+      ::xsd::cxx::xml::dom::create_element (
+        "targetTemp",
+        e));
+
+    s << ::xml_schema::as_double(*i.targetTemp ());
+  }
+
+  // thermoFreq
+  //
+  if (i.thermoFreq ())
+  {
+    ::xercesc::DOMElement& s (
+      ::xsd::cxx::xml::dom::create_element (
+        "thermoFreq",
+        e));
+
+    s << *i.thermoFreq ();
+  }
+
+  // maxTempDelta
+  //
+  if (i.maxTempDelta ())
+  {
+    ::xercesc::DOMElement& s (
+      ::xsd::cxx::xml::dom::create_element (
+        "maxTempDelta",
+        e));
+
+    s << ::xml_schema::as_double(*i.maxTempDelta ());
+  }
+}
+
+void
 operator<< (::xercesc::DOMElement& e, const DecimalList_t& i)
 {
   e << static_cast< const ::xsd::cxx::tree::list< ::xml_schema::decimal, char, ::xsd::cxx::tree::schema_type::decimal >& > (i);
@@ -3656,6 +4518,73 @@ operator<< (::xercesc::DOMElement& e, const ParticleData_t& i)
 }
 
 void
+operator<< (::xercesc::DOMElement& e, const ParticleType_t& i)
+{
+  e << static_cast< const ::xml_schema::type& > (i);
+
+  // sigma
+  //
+  {
+    ::xercesc::DOMElement& s (
+      ::xsd::cxx::xml::dom::create_element (
+        "sigma",
+        e));
+
+    s << ::xml_schema::as_double(i.sigma ());
+  }
+
+  // epsilon
+  //
+  {
+    ::xercesc::DOMElement& s (
+      ::xsd::cxx::xml::dom::create_element (
+        "epsilon",
+        e));
+
+    s << ::xml_schema::as_double(i.epsilon ());
+  }
+}
+
+void
+operator<< (::xercesc::DOMElement& e, const ParticleTypeAttr_t& i)
+{
+  e << static_cast< const ::ParticleType_t& > (i);
+
+  // type
+  //
+  {
+    ::xercesc::DOMAttr& a (
+      ::xsd::cxx::xml::dom::create_attribute (
+        "type",
+        e));
+
+    a << i.type ();
+  }
+}
+
+void
+operator<< (::xercesc::DOMElement& e, const ParticleTypes_t& i)
+{
+  e << static_cast< const ::xml_schema::type& > (i);
+
+  // ptype
+  //
+  for (ParticleTypes_t::ptype_const_iterator
+       b (i.ptype ().begin ()), n (i.ptype ().end ());
+       b != n; ++b)
+  {
+    const ParticleTypes_t::ptype_type& x (*b);
+
+    ::xercesc::DOMElement& s (
+      ::xsd::cxx::xml::dom::create_element (
+        "ptype",
+        e));
+
+    s << x;
+  }
+}
+
+void
 operator<< (::xercesc::DOMElement& e, const cuboid_t& i)
 {
   e << static_cast< const ::xml_schema::type& > (i);
@@ -3735,6 +4664,18 @@ operator<< (::xercesc::DOMElement& e, const cuboid_t& i)
         e));
 
     s << i.brownDim ();
+  }
+
+  // ptype
+  //
+  if (i.ptype ())
+  {
+    ::xercesc::DOMElement& s (
+      ::xsd::cxx::xml::dom::create_element (
+        "ptype",
+        e));
+
+    s << *i.ptype ();
   }
 }
 
@@ -3829,6 +4770,18 @@ operator<< (::xercesc::DOMElement& e, const sphere_t& i)
         e));
 
     s << i.brownDim ();
+  }
+
+  // ptype
+  //
+  if (i.ptype ())
+  {
+    ::xercesc::DOMElement& s (
+      ::xsd::cxx::xml::dom::create_element (
+        "ptype",
+        e));
+
+    s << *i.ptype ();
   }
 }
 
@@ -4018,6 +4971,30 @@ operator<< (::xercesc::DOMElement& e, const params_t& i)
 
     s << *i.boundaries ();
   }
+
+  // thermostat
+  //
+  if (i.thermostat ())
+  {
+    ::xercesc::DOMElement& s (
+      ::xsd::cxx::xml::dom::create_element (
+        "thermostat",
+        e));
+
+    s << *i.thermostat ();
+  }
+
+  // gravity
+  //
+  if (i.gravity ())
+  {
+    ::xercesc::DOMElement& s (
+      ::xsd::cxx::xml::dom::create_element (
+        "gravity",
+        e));
+
+    s << ::xml_schema::as_double(*i.gravity ());
+  }
 }
 
 void
@@ -4045,6 +5022,18 @@ operator<< (::xercesc::DOMElement& e, const simulation_t& i)
         e));
 
     s << i.clusters ();
+  }
+
+  // ptypes
+  //
+  if (i.ptypes ())
+  {
+    ::xercesc::DOMElement& s (
+      ::xsd::cxx::xml::dom::create_element (
+        "ptypes",
+        e));
+
+    s << *i.ptypes ();
   }
 
   // particles

--- a/src/io/xsd/simulation.h
+++ b/src/io/xsd/simulation.h
@@ -621,9 +621,13 @@ class intVec_t;
 class dimension_t;
 class boundaryNames_t;
 class boundary_t;
+class tempParams_t;
 class DecimalList_t;
 class DecimalArray_t;
 class ParticleData_t;
+class ParticleType_t;
+class ParticleTypeAttr_t;
+class ParticleTypes_t;
 class cuboid_t;
 class sphere_t;
 class clusters_t;
@@ -1618,6 +1622,371 @@ class boundary_t: public ::xml_schema::type
 };
 
 /**
+ * @brief Class corresponding to the %tempParams_t schema type.
+ *
+ * @nosubgrouping
+ */
+class tempParams_t: public ::xml_schema::type
+{
+  public:
+  /**
+   * @name initialTemp
+   *
+   * @brief Accessor and modifier functions for the %initialTemp
+   * optional element.
+   *
+   * The initial temperature for the simulation.
+   */
+  //@{
+
+  /**
+   * @brief Element type.
+   */
+  typedef ::xml_schema::double_ initialTemp_type;
+
+  /**
+   * @brief Element optional container type.
+   */
+  typedef ::xsd::cxx::tree::optional< initialTemp_type > initialTemp_optional;
+
+  /**
+   * @brief Element traits type.
+   */
+  typedef ::xsd::cxx::tree::traits< initialTemp_type, char, ::xsd::cxx::tree::schema_type::double_ > initialTemp_traits;
+
+  /**
+   * @brief Return a read-only (constant) reference to the element
+   * container.
+   *
+   * @return A constant reference to the optional container.
+   */
+  const initialTemp_optional&
+  initialTemp () const;
+
+  /**
+   * @brief Return a read-write reference to the element container.
+   *
+   * @return A reference to the optional container.
+   */
+  initialTemp_optional&
+  initialTemp ();
+
+  /**
+   * @brief Set the element value.
+   *
+   * @param x A new value to set.
+   *
+   * This function makes a copy of its argument and sets it as
+   * the new value of the element.
+   */
+  void
+  initialTemp (const initialTemp_type& x);
+
+  /**
+   * @brief Set the element value.
+   *
+   * @param x An optional container with the new value to set.
+   *
+   * If the value is present in @a x then this function makes a copy 
+   * of this value and sets it as the new value of the element.
+   * Otherwise the element container is set the 'not present' state.
+   */
+  void
+  initialTemp (const initialTemp_optional& x);
+
+  //@}
+
+  /**
+   * @name targetTemp
+   *
+   * @brief Accessor and modifier functions for the %targetTemp
+   * optional element.
+   *
+   * The target temperature for the simulation.
+   */
+  //@{
+
+  /**
+   * @brief Element type.
+   */
+  typedef ::xml_schema::double_ targetTemp_type;
+
+  /**
+   * @brief Element optional container type.
+   */
+  typedef ::xsd::cxx::tree::optional< targetTemp_type > targetTemp_optional;
+
+  /**
+   * @brief Element traits type.
+   */
+  typedef ::xsd::cxx::tree::traits< targetTemp_type, char, ::xsd::cxx::tree::schema_type::double_ > targetTemp_traits;
+
+  /**
+   * @brief Return a read-only (constant) reference to the element
+   * container.
+   *
+   * @return A constant reference to the optional container.
+   */
+  const targetTemp_optional&
+  targetTemp () const;
+
+  /**
+   * @brief Return a read-write reference to the element container.
+   *
+   * @return A reference to the optional container.
+   */
+  targetTemp_optional&
+  targetTemp ();
+
+  /**
+   * @brief Set the element value.
+   *
+   * @param x A new value to set.
+   *
+   * This function makes a copy of its argument and sets it as
+   * the new value of the element.
+   */
+  void
+  targetTemp (const targetTemp_type& x);
+
+  /**
+   * @brief Set the element value.
+   *
+   * @param x An optional container with the new value to set.
+   *
+   * If the value is present in @a x then this function makes a copy 
+   * of this value and sets it as the new value of the element.
+   * Otherwise the element container is set the 'not present' state.
+   */
+  void
+  targetTemp (const targetTemp_optional& x);
+
+  //@}
+
+  /**
+   * @name thermoFreq
+   *
+   * @brief Accessor and modifier functions for the %thermoFreq
+   * optional element.
+   *
+   * The frequency of the thermostat for the simulation.
+   */
+  //@{
+
+  /**
+   * @brief Element type.
+   */
+  typedef ::xml_schema::unsigned_int thermoFreq_type;
+
+  /**
+   * @brief Element optional container type.
+   */
+  typedef ::xsd::cxx::tree::optional< thermoFreq_type > thermoFreq_optional;
+
+  /**
+   * @brief Element traits type.
+   */
+  typedef ::xsd::cxx::tree::traits< thermoFreq_type, char > thermoFreq_traits;
+
+  /**
+   * @brief Return a read-only (constant) reference to the element
+   * container.
+   *
+   * @return A constant reference to the optional container.
+   */
+  const thermoFreq_optional&
+  thermoFreq () const;
+
+  /**
+   * @brief Return a read-write reference to the element container.
+   *
+   * @return A reference to the optional container.
+   */
+  thermoFreq_optional&
+  thermoFreq ();
+
+  /**
+   * @brief Set the element value.
+   *
+   * @param x A new value to set.
+   *
+   * This function makes a copy of its argument and sets it as
+   * the new value of the element.
+   */
+  void
+  thermoFreq (const thermoFreq_type& x);
+
+  /**
+   * @brief Set the element value.
+   *
+   * @param x An optional container with the new value to set.
+   *
+   * If the value is present in @a x then this function makes a copy 
+   * of this value and sets it as the new value of the element.
+   * Otherwise the element container is set the 'not present' state.
+   */
+  void
+  thermoFreq (const thermoFreq_optional& x);
+
+  //@}
+
+  /**
+   * @name maxTempDelta
+   *
+   * @brief Accessor and modifier functions for the %maxTempDelta
+   * optional element.
+   *
+   * The maximum allowed change in temperature for the simulation.
+   */
+  //@{
+
+  /**
+   * @brief Element type.
+   */
+  typedef ::xml_schema::double_ maxTempDelta_type;
+
+  /**
+   * @brief Element optional container type.
+   */
+  typedef ::xsd::cxx::tree::optional< maxTempDelta_type > maxTempDelta_optional;
+
+  /**
+   * @brief Element traits type.
+   */
+  typedef ::xsd::cxx::tree::traits< maxTempDelta_type, char, ::xsd::cxx::tree::schema_type::double_ > maxTempDelta_traits;
+
+  /**
+   * @brief Return a read-only (constant) reference to the element
+   * container.
+   *
+   * @return A constant reference to the optional container.
+   */
+  const maxTempDelta_optional&
+  maxTempDelta () const;
+
+  /**
+   * @brief Return a read-write reference to the element container.
+   *
+   * @return A reference to the optional container.
+   */
+  maxTempDelta_optional&
+  maxTempDelta ();
+
+  /**
+   * @brief Set the element value.
+   *
+   * @param x A new value to set.
+   *
+   * This function makes a copy of its argument and sets it as
+   * the new value of the element.
+   */
+  void
+  maxTempDelta (const maxTempDelta_type& x);
+
+  /**
+   * @brief Set the element value.
+   *
+   * @param x An optional container with the new value to set.
+   *
+   * If the value is present in @a x then this function makes a copy 
+   * of this value and sets it as the new value of the element.
+   * Otherwise the element container is set the 'not present' state.
+   */
+  void
+  maxTempDelta (const maxTempDelta_optional& x);
+
+  //@}
+
+  /**
+   * @name Constructors
+   */
+  //@{
+
+  /**
+   * @brief Create an instance from the ultimate base and
+   * initializers for required elements and attributes.
+   */
+  tempParams_t ();
+
+  /**
+   * @brief Create an instance from a DOM element.
+   *
+   * @param e A DOM element to extract the data from.
+   * @param f Flags to create the new instance with.
+   * @param c A pointer to the object that will contain the new
+   * instance.
+   */
+  tempParams_t (const ::xercesc::DOMElement& e,
+                ::xml_schema::flags f = 0,
+                ::xml_schema::container* c = 0);
+
+  /**
+   * @brief Copy constructor.
+   *
+   * @param x An instance to make a copy of.
+   * @param f Flags to create the copy with.
+   * @param c A pointer to the object that will contain the copy.
+   *
+   * For polymorphic object models use the @c _clone function instead.
+   */
+  tempParams_t (const tempParams_t& x,
+                ::xml_schema::flags f = 0,
+                ::xml_schema::container* c = 0);
+
+  /**
+   * @brief Copy the instance polymorphically.
+   *
+   * @param f Flags to create the copy with.
+   * @param c A pointer to the object that will contain the copy.
+   * @return A pointer to the dynamically allocated copy.
+   *
+   * This function ensures that the dynamic type of the instance is
+   * used for copying and should be used for polymorphic object
+   * models instead of the copy constructor.
+   */
+  virtual tempParams_t*
+  _clone (::xml_schema::flags f = 0,
+          ::xml_schema::container* c = 0) const;
+
+  /**
+   * @brief Copy assignment operator.
+   *
+   * @param x An instance to make a copy of.
+   * @return A reference to itself.
+   *
+   * For polymorphic object models use the @c _clone function instead.
+   */
+  tempParams_t&
+  operator= (const tempParams_t& x);
+
+  //@}
+
+  /**
+   * @brief Destructor.
+   */
+  virtual 
+  ~tempParams_t ();
+
+  // Implementation.
+  //
+
+  //@cond
+
+  protected:
+  void
+  parse (::xsd::cxx::xml::dom::parser< char >&,
+         ::xml_schema::flags);
+
+  protected:
+  initialTemp_optional initialTemp_;
+  targetTemp_optional targetTemp_;
+  thermoFreq_optional thermoFreq_;
+  maxTempDelta_optional maxTempDelta_;
+
+  //@endcond
+};
+
+/**
  * @brief List class corresponding to the %DecimalList_t
  * schema type.
  *
@@ -2365,6 +2734,497 @@ class ParticleData_t: public ::xml_schema::type
 };
 
 /**
+ * @brief Class corresponding to the %ParticleType_t schema type.
+ *
+ * @nosubgrouping
+ */
+class ParticleType_t: public ::xml_schema::type
+{
+  public:
+  /**
+   * @name sigma
+   *
+   * @brief Accessor and modifier functions for the %sigma
+   * required element.
+   */
+  //@{
+
+  /**
+   * @brief Element type.
+   */
+  typedef ::xml_schema::double_ sigma_type;
+
+  /**
+   * @brief Element traits type.
+   */
+  typedef ::xsd::cxx::tree::traits< sigma_type, char, ::xsd::cxx::tree::schema_type::double_ > sigma_traits;
+
+  /**
+   * @brief Return a read-only (constant) reference to the element.
+   *
+   * @return A constant reference to the element.
+   */
+  const sigma_type&
+  sigma () const;
+
+  /**
+   * @brief Return a read-write reference to the element.
+   *
+   * @return A reference to the element.
+   */
+  sigma_type&
+  sigma ();
+
+  /**
+   * @brief Set the element value.
+   *
+   * @param x A new value to set.
+   *
+   * This function makes a copy of its argument and sets it as
+   * the new value of the element.
+   */
+  void
+  sigma (const sigma_type& x);
+
+  //@}
+
+  /**
+   * @name epsilon
+   *
+   * @brief Accessor and modifier functions for the %epsilon
+   * required element.
+   */
+  //@{
+
+  /**
+   * @brief Element type.
+   */
+  typedef ::xml_schema::double_ epsilon_type;
+
+  /**
+   * @brief Element traits type.
+   */
+  typedef ::xsd::cxx::tree::traits< epsilon_type, char, ::xsd::cxx::tree::schema_type::double_ > epsilon_traits;
+
+  /**
+   * @brief Return a read-only (constant) reference to the element.
+   *
+   * @return A constant reference to the element.
+   */
+  const epsilon_type&
+  epsilon () const;
+
+  /**
+   * @brief Return a read-write reference to the element.
+   *
+   * @return A reference to the element.
+   */
+  epsilon_type&
+  epsilon ();
+
+  /**
+   * @brief Set the element value.
+   *
+   * @param x A new value to set.
+   *
+   * This function makes a copy of its argument and sets it as
+   * the new value of the element.
+   */
+  void
+  epsilon (const epsilon_type& x);
+
+  //@}
+
+  /**
+   * @name Constructors
+   */
+  //@{
+
+  /**
+   * @brief Create an instance from the ultimate base and
+   * initializers for required elements and attributes.
+   */
+  ParticleType_t (const sigma_type&,
+                  const epsilon_type&);
+
+  /**
+   * @brief Create an instance from a DOM element.
+   *
+   * @param e A DOM element to extract the data from.
+   * @param f Flags to create the new instance with.
+   * @param c A pointer to the object that will contain the new
+   * instance.
+   */
+  ParticleType_t (const ::xercesc::DOMElement& e,
+                  ::xml_schema::flags f = 0,
+                  ::xml_schema::container* c = 0);
+
+  /**
+   * @brief Copy constructor.
+   *
+   * @param x An instance to make a copy of.
+   * @param f Flags to create the copy with.
+   * @param c A pointer to the object that will contain the copy.
+   *
+   * For polymorphic object models use the @c _clone function instead.
+   */
+  ParticleType_t (const ParticleType_t& x,
+                  ::xml_schema::flags f = 0,
+                  ::xml_schema::container* c = 0);
+
+  /**
+   * @brief Copy the instance polymorphically.
+   *
+   * @param f Flags to create the copy with.
+   * @param c A pointer to the object that will contain the copy.
+   * @return A pointer to the dynamically allocated copy.
+   *
+   * This function ensures that the dynamic type of the instance is
+   * used for copying and should be used for polymorphic object
+   * models instead of the copy constructor.
+   */
+  virtual ParticleType_t*
+  _clone (::xml_schema::flags f = 0,
+          ::xml_schema::container* c = 0) const;
+
+  /**
+   * @brief Copy assignment operator.
+   *
+   * @param x An instance to make a copy of.
+   * @return A reference to itself.
+   *
+   * For polymorphic object models use the @c _clone function instead.
+   */
+  ParticleType_t&
+  operator= (const ParticleType_t& x);
+
+  //@}
+
+  /**
+   * @brief Destructor.
+   */
+  virtual 
+  ~ParticleType_t ();
+
+  // Implementation.
+  //
+
+  //@cond
+
+  protected:
+  void
+  parse (::xsd::cxx::xml::dom::parser< char >&,
+         ::xml_schema::flags);
+
+  protected:
+  ::xsd::cxx::tree::one< sigma_type > sigma_;
+  ::xsd::cxx::tree::one< epsilon_type > epsilon_;
+
+  //@endcond
+};
+
+/**
+ * @brief Class corresponding to the %ParticleTypeAttr_t schema type.
+ *
+ * @nosubgrouping
+ */
+class ParticleTypeAttr_t: public ::ParticleType_t
+{
+  public:
+  /**
+   * @name type
+   *
+   * @brief Accessor and modifier functions for the %type
+   * required attribute.
+   */
+  //@{
+
+  /**
+   * @brief Attribute type.
+   */
+  typedef ::xml_schema::unsigned_int type_type;
+
+  /**
+   * @brief Attribute traits type.
+   */
+  typedef ::xsd::cxx::tree::traits< type_type, char > type_traits;
+
+  /**
+   * @brief Return a read-only (constant) reference to the attribute.
+   *
+   * @return A constant reference to the attribute.
+   */
+  const type_type&
+  type () const;
+
+  /**
+   * @brief Return a read-write reference to the attribute.
+   *
+   * @return A reference to the attribute.
+   */
+  type_type&
+  type ();
+
+  /**
+   * @brief Set the attribute value.
+   *
+   * @param x A new value to set.
+   *
+   * This function makes a copy of its argument and sets it as
+   * the new value of the attribute.
+   */
+  void
+  type (const type_type& x);
+
+  //@}
+
+  /**
+   * @name Constructors
+   */
+  //@{
+
+  /**
+   * @brief Create an instance from the ultimate base and
+   * initializers for required elements and attributes.
+   */
+  ParticleTypeAttr_t (const sigma_type&,
+                      const epsilon_type&,
+                      const type_type&);
+
+  /**
+   * @brief Create an instance from a DOM element.
+   *
+   * @param e A DOM element to extract the data from.
+   * @param f Flags to create the new instance with.
+   * @param c A pointer to the object that will contain the new
+   * instance.
+   */
+  ParticleTypeAttr_t (const ::xercesc::DOMElement& e,
+                      ::xml_schema::flags f = 0,
+                      ::xml_schema::container* c = 0);
+
+  /**
+   * @brief Copy constructor.
+   *
+   * @param x An instance to make a copy of.
+   * @param f Flags to create the copy with.
+   * @param c A pointer to the object that will contain the copy.
+   *
+   * For polymorphic object models use the @c _clone function instead.
+   */
+  ParticleTypeAttr_t (const ParticleTypeAttr_t& x,
+                      ::xml_schema::flags f = 0,
+                      ::xml_schema::container* c = 0);
+
+  /**
+   * @brief Copy the instance polymorphically.
+   *
+   * @param f Flags to create the copy with.
+   * @param c A pointer to the object that will contain the copy.
+   * @return A pointer to the dynamically allocated copy.
+   *
+   * This function ensures that the dynamic type of the instance is
+   * used for copying and should be used for polymorphic object
+   * models instead of the copy constructor.
+   */
+  virtual ParticleTypeAttr_t*
+  _clone (::xml_schema::flags f = 0,
+          ::xml_schema::container* c = 0) const;
+
+  /**
+   * @brief Copy assignment operator.
+   *
+   * @param x An instance to make a copy of.
+   * @return A reference to itself.
+   *
+   * For polymorphic object models use the @c _clone function instead.
+   */
+  ParticleTypeAttr_t&
+  operator= (const ParticleTypeAttr_t& x);
+
+  //@}
+
+  /**
+   * @brief Destructor.
+   */
+  virtual 
+  ~ParticleTypeAttr_t ();
+
+  // Implementation.
+  //
+
+  //@cond
+
+  protected:
+  void
+  parse (::xsd::cxx::xml::dom::parser< char >&,
+         ::xml_schema::flags);
+
+  protected:
+  ::xsd::cxx::tree::one< type_type > type_;
+
+  //@endcond
+};
+
+/**
+ * @brief Class corresponding to the %ParticleTypes_t schema type.
+ *
+ * @nosubgrouping
+ */
+class ParticleTypes_t: public ::xml_schema::type
+{
+  public:
+  /**
+   * @name ptype
+   *
+   * @brief Accessor and modifier functions for the %ptype
+   * sequence element.
+   */
+  //@{
+
+  /**
+   * @brief Element type.
+   */
+  typedef ::ParticleTypeAttr_t ptype_type;
+
+  /**
+   * @brief Element sequence container type.
+   */
+  typedef ::xsd::cxx::tree::sequence< ptype_type > ptype_sequence;
+
+  /**
+   * @brief Element iterator type.
+   */
+  typedef ptype_sequence::iterator ptype_iterator;
+
+  /**
+   * @brief Element constant iterator type.
+   */
+  typedef ptype_sequence::const_iterator ptype_const_iterator;
+
+  /**
+   * @brief Element traits type.
+   */
+  typedef ::xsd::cxx::tree::traits< ptype_type, char > ptype_traits;
+
+  /**
+   * @brief Return a read-only (constant) reference to the element
+   * sequence.
+   *
+   * @return A constant reference to the sequence container.
+   */
+  const ptype_sequence&
+  ptype () const;
+
+  /**
+   * @brief Return a read-write reference to the element sequence.
+   *
+   * @return A reference to the sequence container.
+   */
+  ptype_sequence&
+  ptype ();
+
+  /**
+   * @brief Copy elements from a given sequence.
+   *
+   * @param s A sequence to copy elements from.
+   *
+   * For each element in @a s this function makes a copy and adds it 
+   * to the sequence. Note that this operation completely changes the 
+   * sequence and all old elements will be lost.
+   */
+  void
+  ptype (const ptype_sequence& s);
+
+  //@}
+
+  /**
+   * @name Constructors
+   */
+  //@{
+
+  /**
+   * @brief Create an instance from the ultimate base and
+   * initializers for required elements and attributes.
+   */
+  ParticleTypes_t ();
+
+  /**
+   * @brief Create an instance from a DOM element.
+   *
+   * @param e A DOM element to extract the data from.
+   * @param f Flags to create the new instance with.
+   * @param c A pointer to the object that will contain the new
+   * instance.
+   */
+  ParticleTypes_t (const ::xercesc::DOMElement& e,
+                   ::xml_schema::flags f = 0,
+                   ::xml_schema::container* c = 0);
+
+  /**
+   * @brief Copy constructor.
+   *
+   * @param x An instance to make a copy of.
+   * @param f Flags to create the copy with.
+   * @param c A pointer to the object that will contain the copy.
+   *
+   * For polymorphic object models use the @c _clone function instead.
+   */
+  ParticleTypes_t (const ParticleTypes_t& x,
+                   ::xml_schema::flags f = 0,
+                   ::xml_schema::container* c = 0);
+
+  /**
+   * @brief Copy the instance polymorphically.
+   *
+   * @param f Flags to create the copy with.
+   * @param c A pointer to the object that will contain the copy.
+   * @return A pointer to the dynamically allocated copy.
+   *
+   * This function ensures that the dynamic type of the instance is
+   * used for copying and should be used for polymorphic object
+   * models instead of the copy constructor.
+   */
+  virtual ParticleTypes_t*
+  _clone (::xml_schema::flags f = 0,
+          ::xml_schema::container* c = 0) const;
+
+  /**
+   * @brief Copy assignment operator.
+   *
+   * @param x An instance to make a copy of.
+   * @return A reference to itself.
+   *
+   * For polymorphic object models use the @c _clone function instead.
+   */
+  ParticleTypes_t&
+  operator= (const ParticleTypes_t& x);
+
+  //@}
+
+  /**
+   * @brief Destructor.
+   */
+  virtual 
+  ~ParticleTypes_t ();
+
+  // Implementation.
+  //
+
+  //@cond
+
+  protected:
+  void
+  parse (::xsd::cxx::xml::dom::parser< char >&,
+         ::xml_schema::flags);
+
+  protected:
+  ptype_sequence ptype_;
+
+  //@endcond
+};
+
+/**
  * @brief Class corresponding to the %cuboid_t schema type.
  *
  * Defines the properties of a cuboid-shaped cluster.
@@ -2763,6 +3623,73 @@ class cuboid_t: public ::xml_schema::type
   //@}
 
   /**
+   * @name ptype
+   *
+   * @brief Accessor and modifier functions for the %ptype
+   * optional element.
+   *
+   * The particle type of the cuboid.
+   */
+  //@{
+
+  /**
+   * @brief Element type.
+   */
+  typedef ::xml_schema::unsigned_int ptype_type;
+
+  /**
+   * @brief Element optional container type.
+   */
+  typedef ::xsd::cxx::tree::optional< ptype_type > ptype_optional;
+
+  /**
+   * @brief Element traits type.
+   */
+  typedef ::xsd::cxx::tree::traits< ptype_type, char > ptype_traits;
+
+  /**
+   * @brief Return a read-only (constant) reference to the element
+   * container.
+   *
+   * @return A constant reference to the optional container.
+   */
+  const ptype_optional&
+  ptype () const;
+
+  /**
+   * @brief Return a read-write reference to the element container.
+   *
+   * @return A reference to the optional container.
+   */
+  ptype_optional&
+  ptype ();
+
+  /**
+   * @brief Set the element value.
+   *
+   * @param x A new value to set.
+   *
+   * This function makes a copy of its argument and sets it as
+   * the new value of the element.
+   */
+  void
+  ptype (const ptype_type& x);
+
+  /**
+   * @brief Set the element value.
+   *
+   * @param x An optional container with the new value to set.
+   *
+   * If the value is present in @a x then this function makes a copy 
+   * of this value and sets it as the new value of the element.
+   * Otherwise the element container is set the 'not present' state.
+   */
+  void
+  ptype (const ptype_optional& x);
+
+  //@}
+
+  /**
    * @name Constructors
    */
   //@{
@@ -2872,6 +3799,7 @@ class cuboid_t: public ::xml_schema::type
   ::xsd::cxx::tree::one< spacing_type > spacing_;
   ::xsd::cxx::tree::one< brownVel_type > brownVel_;
   ::xsd::cxx::tree::one< brownDim_type > brownDim_;
+  ptype_optional ptype_;
 
   //@endcond
 };
@@ -3323,6 +4251,73 @@ class sphere_t: public ::xml_schema::type
   //@}
 
   /**
+   * @name ptype
+   *
+   * @brief Accessor and modifier functions for the %ptype
+   * optional element.
+   *
+   * The particle type of the cuboid.
+   */
+  //@{
+
+  /**
+   * @brief Element type.
+   */
+  typedef ::xml_schema::unsigned_int ptype_type;
+
+  /**
+   * @brief Element optional container type.
+   */
+  typedef ::xsd::cxx::tree::optional< ptype_type > ptype_optional;
+
+  /**
+   * @brief Element traits type.
+   */
+  typedef ::xsd::cxx::tree::traits< ptype_type, char > ptype_traits;
+
+  /**
+   * @brief Return a read-only (constant) reference to the element
+   * container.
+   *
+   * @return A constant reference to the optional container.
+   */
+  const ptype_optional&
+  ptype () const;
+
+  /**
+   * @brief Return a read-write reference to the element container.
+   *
+   * @return A reference to the optional container.
+   */
+  ptype_optional&
+  ptype ();
+
+  /**
+   * @brief Set the element value.
+   *
+   * @param x A new value to set.
+   *
+   * This function makes a copy of its argument and sets it as
+   * the new value of the element.
+   */
+  void
+  ptype (const ptype_type& x);
+
+  /**
+   * @brief Set the element value.
+   *
+   * @param x An optional container with the new value to set.
+   *
+   * If the value is present in @a x then this function makes a copy 
+   * of this value and sets it as the new value of the element.
+   * Otherwise the element container is set the 'not present' state.
+   */
+  void
+  ptype (const ptype_optional& x);
+
+  //@}
+
+  /**
    * @name Constructors
    */
   //@{
@@ -3435,6 +4430,7 @@ class sphere_t: public ::xml_schema::type
   ::xsd::cxx::tree::one< spacing_type > spacing_;
   ::xsd::cxx::tree::one< brownVel_type > brownVel_;
   ::xsd::cxx::tree::one< brownDim_type > brownDim_;
+  ptype_optional ptype_;
 
   //@endcond
 };
@@ -4527,6 +5523,152 @@ class params_t: public ::xml_schema::type
   //@}
 
   /**
+   * @name thermostat
+   *
+   * @brief Accessor and modifier functions for the %thermostat
+   * optional element.
+   *
+   * The thermostat configuration for the simulation.
+   */
+  //@{
+
+  /**
+   * @brief Element type.
+   */
+  typedef ::tempParams_t thermostat_type;
+
+  /**
+   * @brief Element optional container type.
+   */
+  typedef ::xsd::cxx::tree::optional< thermostat_type > thermostat_optional;
+
+  /**
+   * @brief Element traits type.
+   */
+  typedef ::xsd::cxx::tree::traits< thermostat_type, char > thermostat_traits;
+
+  /**
+   * @brief Return a read-only (constant) reference to the element
+   * container.
+   *
+   * @return A constant reference to the optional container.
+   */
+  const thermostat_optional&
+  thermostat () const;
+
+  /**
+   * @brief Return a read-write reference to the element container.
+   *
+   * @return A reference to the optional container.
+   */
+  thermostat_optional&
+  thermostat ();
+
+  /**
+   * @brief Set the element value.
+   *
+   * @param x A new value to set.
+   *
+   * This function makes a copy of its argument and sets it as
+   * the new value of the element.
+   */
+  void
+  thermostat (const thermostat_type& x);
+
+  /**
+   * @brief Set the element value.
+   *
+   * @param x An optional container with the new value to set.
+   *
+   * If the value is present in @a x then this function makes a copy 
+   * of this value and sets it as the new value of the element.
+   * Otherwise the element container is set the 'not present' state.
+   */
+  void
+  thermostat (const thermostat_optional& x);
+
+  /**
+   * @brief Set the element value without copying.
+   *
+   * @param p A new value to use.
+   *
+   * This function will try to use the passed value directly instead
+   * of making a copy.
+   */
+  void
+  thermostat (::std::unique_ptr< thermostat_type > p);
+
+  //@}
+
+  /**
+   * @name gravity
+   *
+   * @brief Accessor and modifier functions for the %gravity
+   * optional element.
+   *
+   * The gravitational constant for the gravitational force along the
+   * y-axis.
+   */
+  //@{
+
+  /**
+   * @brief Element type.
+   */
+  typedef ::xml_schema::double_ gravity_type;
+
+  /**
+   * @brief Element optional container type.
+   */
+  typedef ::xsd::cxx::tree::optional< gravity_type > gravity_optional;
+
+  /**
+   * @brief Element traits type.
+   */
+  typedef ::xsd::cxx::tree::traits< gravity_type, char, ::xsd::cxx::tree::schema_type::double_ > gravity_traits;
+
+  /**
+   * @brief Return a read-only (constant) reference to the element
+   * container.
+   *
+   * @return A constant reference to the optional container.
+   */
+  const gravity_optional&
+  gravity () const;
+
+  /**
+   * @brief Return a read-write reference to the element container.
+   *
+   * @return A reference to the optional container.
+   */
+  gravity_optional&
+  gravity ();
+
+  /**
+   * @brief Set the element value.
+   *
+   * @param x A new value to set.
+   *
+   * This function makes a copy of its argument and sets it as
+   * the new value of the element.
+   */
+  void
+  gravity (const gravity_type& x);
+
+  /**
+   * @brief Set the element value.
+   *
+   * @param x An optional container with the new value to set.
+   *
+   * If the value is present in @a x then this function makes a copy 
+   * of this value and sets it as the new value of the element.
+   * Otherwise the element container is set the 'not present' state.
+   */
+  void
+  gravity (const gravity_optional& x);
+
+  //@}
+
+  /**
    * @name Constructors
    */
   //@{
@@ -4619,6 +5761,8 @@ class params_t: public ::xml_schema::type
   cutoff_optional cutoff_;
   updateFreq_optional updateFreq_;
   boundaries_optional boundaries_;
+  thermostat_optional thermostat_;
+  gravity_optional gravity_;
 
   //@endcond
 };
@@ -4750,6 +5894,84 @@ class simulation_t: public ::xml_schema::type
    */
   void
   clusters (::std::unique_ptr< clusters_type > p);
+
+  //@}
+
+  /**
+   * @name ptypes
+   *
+   * @brief Accessor and modifier functions for the %ptypes
+   * optional element.
+   *
+   * The collection of clusters to be simulated.
+   */
+  //@{
+
+  /**
+   * @brief Element type.
+   */
+  typedef ::ParticleTypes_t ptypes_type;
+
+  /**
+   * @brief Element optional container type.
+   */
+  typedef ::xsd::cxx::tree::optional< ptypes_type > ptypes_optional;
+
+  /**
+   * @brief Element traits type.
+   */
+  typedef ::xsd::cxx::tree::traits< ptypes_type, char > ptypes_traits;
+
+  /**
+   * @brief Return a read-only (constant) reference to the element
+   * container.
+   *
+   * @return A constant reference to the optional container.
+   */
+  const ptypes_optional&
+  ptypes () const;
+
+  /**
+   * @brief Return a read-write reference to the element container.
+   *
+   * @return A reference to the optional container.
+   */
+  ptypes_optional&
+  ptypes ();
+
+  /**
+   * @brief Set the element value.
+   *
+   * @param x A new value to set.
+   *
+   * This function makes a copy of its argument and sets it as
+   * the new value of the element.
+   */
+  void
+  ptypes (const ptypes_type& x);
+
+  /**
+   * @brief Set the element value.
+   *
+   * @param x An optional container with the new value to set.
+   *
+   * If the value is present in @a x then this function makes a copy 
+   * of this value and sets it as the new value of the element.
+   * Otherwise the element container is set the 'not present' state.
+   */
+  void
+  ptypes (const ptypes_optional& x);
+
+  /**
+   * @brief Set the element value without copying.
+   *
+   * @param p A new value to use.
+   *
+   * This function will try to use the passed value directly instead
+   * of making a copy.
+   */
+  void
+  ptypes (::std::unique_ptr< ptypes_type > p);
 
   //@}
 
@@ -4926,6 +6148,7 @@ class simulation_t: public ::xml_schema::type
   protected:
   ::xsd::cxx::tree::one< params_type > params_;
   ::xsd::cxx::tree::one< clusters_type > clusters_;
+  ptypes_optional ptypes_;
   particles_optional particles_;
 
   //@endcond
@@ -5230,6 +6453,9 @@ void
 operator<< (::xercesc::DOMElement&, const boundary_t&);
 
 void
+operator<< (::xercesc::DOMElement&, const tempParams_t&);
+
+void
 operator<< (::xercesc::DOMElement&, const DecimalList_t&);
 
 void
@@ -5244,6 +6470,15 @@ operator<< (::xercesc::DOMElement&, const DecimalArray_t&);
 
 void
 operator<< (::xercesc::DOMElement&, const ParticleData_t&);
+
+void
+operator<< (::xercesc::DOMElement&, const ParticleType_t&);
+
+void
+operator<< (::xercesc::DOMElement&, const ParticleTypeAttr_t&);
+
+void
+operator<< (::xercesc::DOMElement&, const ParticleTypes_t&);
 
 void
 operator<< (::xercesc::DOMElement&, const cuboid_t&);

--- a/src/io/xsd/simulation.xsd
+++ b/src/io/xsd/simulation.xsd
@@ -106,6 +106,39 @@
         </xs:choice>
 </xs:complexType>
 
+<xs:complexType name="tempParams_t">
+    <xs:sequence>
+        <xs:element name="initialTemp" type="xs:double" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+              The initial temperature for the simulation.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="targetTemp" type="xs:double" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+              The target temperature for the simulation.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+       <xs:element name="thermoFreq" type="xs:unsignedInt" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+              The frequency of the thermostat for the simulation.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="maxTempDelta" type="xs:double" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+              The maximum allowed change in temperature for the simulation.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+</xs:complexType>
+
    <!-- Particle data definitions -->
 
    <xs:simpleType name='DecimalList_t'>
@@ -130,6 +163,28 @@
         <xs:element name="OldForceData" type="DecimalArray_t"/>
         <xs:element name="MassData" type="DecimalArray_t"/>
         <xs:element name="TypeData" type="DecimalArray_t"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <!-- Particle type definitions -->
+  <xs:complexType name="ParticleType_t">
+    <xs:sequence>
+      <xs:element name="sigma" type="xs:double"/>
+      <xs:element name="epsilon" type="xs:double"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="ParticleTypeAttr_t">
+    <xs:complexContent>
+      <xs:extension base="ParticleType_t">
+        <xs:attribute name="type" type="xs:unsignedInt" use="required"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="ParticleTypes_t">
+    <xs:sequence>
+      <xs:element name="ptype" type="ParticleTypeAttr_t" maxOccurs="unbounded"/>
     </xs:sequence>
   </xs:complexType>
 
@@ -189,6 +244,13 @@
         <xs:annotation>
           <xs:documentation>
             The dimension affected by Brownian motion.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ptype" type="xs:unsignedInt" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            The particle type of the cuboid.
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -258,6 +320,13 @@
           </xs:documentation>
         </xs:annotation>
       </xs:element>
+       <xs:element name="ptype" type="xs:unsignedInt" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            The particle type of the cuboid.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
     </xs:sequence>
   </xs:complexType>
 
@@ -295,7 +364,7 @@
         Defines the parameters for the simulation.
       </xs:documentation>
     </xs:annotation>
-    <xs:sequence>
+    <xs:all>
       <xs:element name="start_time" type="xs:double" minOccurs="0">
         <xs:annotation>
           <xs:documentation>
@@ -380,7 +449,21 @@
           </xs:documentation>
         </xs:annotation>
       </xs:element>
-    </xs:sequence>
+      <xs:element name="thermostat" type="tempParams_t" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+              The thermostat configuration for the simulation.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="gravity" type="xs:double" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+              The gravitational constant for the gravitational force along the y-axis.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:all>
   </xs:complexType>
 
   <!-- Simulation type definition -->
@@ -400,6 +483,13 @@
         </xs:annotation>
       </xs:element>
       <xs:element name="clusters" type="clusters_t">
+        <xs:annotation>
+          <xs:documentation>
+            The collection of clusters to be simulated.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ptypes" type="ParticleTypes_t" minOccurs="0">
         <xs:annotation>
           <xs:documentation>
             The collection of clusters to be simulated.

--- a/src/models/generators/CuboidParticleCluster.cpp
+++ b/src/models/generators/CuboidParticleCluster.cpp
@@ -10,8 +10,9 @@ CuboidParticleCluster::CuboidParticleCluster(
     double mass,
     std::array<double, 3> initialVelocity,
     double meanVelocity,
-    size_t dimensions)
-    : ParticleCluster(origin, mass, initialVelocity, meanVelocity, dimensions)
+    size_t dimensions,
+    unsigned ptype)
+    : ParticleCluster(origin, mass, initialVelocity, meanVelocity, dimensions, ptype)
     , numParticlesWidth(numParticlesWidth)
     , numParticlesHeight(numParticlesHeight)
     , numParticlesDepth(numParticlesDepth)
@@ -41,7 +42,7 @@ void CuboidParticleCluster::generateCluster(
                     initialVelocity + maxwellBoltzmannDistributedVelocity(meanVelocity, dimensions);
 
                 // Create particle
-                Particle particle = Particle(position, velocity, mass);
+                Particle particle = Particle(position, velocity, mass, ptype);
 
                 // Add particle to container
                 particles[insertionIndex++] = particle;
@@ -58,8 +59,10 @@ std::string CuboidParticleCluster::toString() const
     oss << "pos: (" << origin[0] << ", " << origin[1] << ", " << origin[2] << ") ";
     oss << "vel: (" << initialVelocity[0] << ", " << initialVelocity[1] << ", "
         << initialVelocity[2] << ") ";
-    oss << "dim: (" << numParticlesWidth << ", " << numParticlesHeight << ", " << numParticlesDepth << ") ";
+    oss << "dim: (" << numParticlesWidth << ", " << numParticlesHeight << ", " << numParticlesDepth
+        << ") ";
     oss << "mass: " << mass << " ";
+    oss << "ptype: " << ptype << " ";
     oss << "meanVel: " << meanVelocity << " ";
     oss << "brownDim: " << dimensions << " ";
     oss << "spacing: " << spacing << " ";

--- a/src/models/generators/CuboidParticleCluster.h
+++ b/src/models/generators/CuboidParticleCluster.h
@@ -21,6 +21,7 @@ public:
      * maxwellBoltzmannDistributedVelocity() The dimensions of the cluster (<= 3) will be passed to
      * maxwellBoltzmannDistributedVelocity() if set to 0 no brownian motion will be added, if set to
      * 1 then only on the x axis, then x+y, and finally x+y+z axis
+     * @param ptype The particle type for this cluster
      */
     CuboidParticleCluster(
         std::array<double, 3> origin,
@@ -31,7 +32,8 @@ public:
         double mass,
         std::array<double, 3> initialVelocity,
         double meanVelocity,
-        size_t dimensions);
+        size_t dimensions,
+        unsigned ptype = 0);
 
     /**
      * @brief Get the total number of particles in the cluster

--- a/src/models/generators/ParticleCluster.cpp
+++ b/src/models/generators/ParticleCluster.cpp
@@ -6,12 +6,14 @@ ParticleCluster::ParticleCluster(
     double mass,
     std::array<double, 3> initialVelocity,
     double meanVelocity,
-    size_t dimensions)
+    size_t dimensions,
+    unsigned ptype)
     : origin(origin)
     , mass(mass)
     , initialVelocity(initialVelocity)
     , meanVelocity(meanVelocity)
     , dimensions(dimensions)
+    , ptype(ptype)
 {
     if (dimensions > 3) {
         spdlog::warn(

--- a/src/models/generators/ParticleCluster.h
+++ b/src/models/generators/ParticleCluster.h
@@ -5,7 +5,6 @@
 #include "utils/ArrayUtils.h"
 #include "utils/MaxwellBoltzmannDistribution.h"
 #include <spdlog/spdlog.h>
-#include <sstream>
 #include <vector>
 
 /**
@@ -23,13 +22,15 @@ public:
      * maxwellBoltzmannDistributedVelocity() The dimensions of the cluster (<= 3) will be passed to
      * maxwellBoltzmannDistributedVelocity() if set to 0 no brownian motion will be added, if set to
      * 1 then only on the x axis, then x+y, and finally x+y+z axis
+     * @param ptype The particle type for this cluster
      */
     ParticleCluster(
         std::array<double, 3> origin,
         double mass,
         std::array<double, 3> initialVelocity,
         double meanVelocity,
-        size_t dimensions);
+        size_t dimensions,
+        unsigned ptype);
 
     /**
      * @brief Destructor for the ParticleCluster class
@@ -60,4 +61,5 @@ protected:
     std::array<double, 3> initialVelocity; /**< The initial velocity of the particles */
     double meanVelocity; /**< The mean velocity of the particles */
     size_t dimensions; /**< The dimensions of the cluster (2 or 3) */
+    unsigned ptype; /**< The particle type for this cluster */
 };

--- a/src/models/generators/SphereParticleCluster.cpp
+++ b/src/models/generators/SphereParticleCluster.cpp
@@ -10,8 +10,9 @@ SphereParticleCluster::SphereParticleCluster(
     double mass,
     std::array<double, 3> initialVelocity,
     double meanVelocity,
-    size_t brownianMotionDimensions)
-    : ParticleCluster(origin, mass, initialVelocity, meanVelocity, brownianMotionDimensions)
+    size_t brownianMotionDimensions,
+    unsigned ptype)
+    : ParticleCluster(origin, mass, initialVelocity, meanVelocity, brownianMotionDimensions, ptype)
     , sphereRadius(radius)
     , sphereDimensions(sphereDimensions)
     , spacing(spacing)
@@ -58,7 +59,7 @@ void SphereParticleCluster::generateRing(
         std::array<double, 3> position { origin[0], origin[1], origin[2] + z_offset };
         std::array<double, 3> velocity =
             initialVelocity + maxwellBoltzmannDistributedVelocity(meanVelocity, dimensions);
-        Particle particle = Particle(position, velocity, mass);
+        Particle particle = Particle(position, velocity, mass, ptype);
 
         particles[insertionIndex++] = particle;
     } else if (realRadius >= spacing) {
@@ -80,7 +81,7 @@ void SphereParticleCluster::generateRing(
 
             std::array<double, 3> velocity =
                 initialVelocity + maxwellBoltzmannDistributedVelocity(meanVelocity, dimensions);
-            Particle particle = Particle(position, velocity, mass);
+            Particle particle = Particle(position, velocity, mass, ptype);
 
             particles[insertionIndex++] = particle;
 
@@ -182,6 +183,7 @@ std::string SphereParticleCluster::toString() const
     oss << "radius: " << sphereRadius << " ";
     oss << "sphereDim: " << sphereDimensions << " ";
     oss << "mass: " << mass << " ";
+    oss << "ptype: " << ptype << " ";
     oss << "meanVel: " << meanVelocity << " ";
     oss << "brownDim: " << dimensions << " ";
     oss << "spacing: " << spacing << " ";

--- a/src/models/generators/SphereParticleCluster.h
+++ b/src/models/generators/SphereParticleCluster.h
@@ -32,7 +32,8 @@ public:
         double mass,
         std::array<double, 3> initialVelocity,
         double meanVelocity,
-        size_t brownianMotionDimensions);
+        size_t brownianMotionDimensions,
+        unsigned ptype = 0);
 
     /**
      * @brief Get the total number of particles in the cluster

--- a/src/utils/Params.h
+++ b/src/utils/Params.h
@@ -49,4 +49,18 @@ public:
                                     BoundaryType::SOFT_REFLECTIVE,
                                     BoundaryType::SOFT_REFLECTIVE,
                                     BoundaryType::SOFT_REFLECTIVE };
+    // initial temperature
+    double init_temp = 0;
+    // target temperature
+    double target_temp = 0;
+    // frequency of thermostat updates
+    unsigned thermo_freq = 0;
+    // maximum temperature delta
+    double max_temp_delta = 0.01;
+    // gravitational constant
+    double gravity = 0.0;
+    // particle types 
+    std::vector<std::pair<double, double>> particleTypes;
+    // map to particle types
+    std::map<unsigned, std::pair<double, double>> typesMap;
 };


### PR DESCRIPTION
Mit dieser PR haben wir nun ein vervollständigtes XML-format, dass alle benötigten Parameter spezifiziert, dazu die überarbeiteten `xmlparse.cpp` und `xmlReader.cpp`.
Schau dir gerne einfach die neue Input file, die `small_reileigh_taylor.xml`, an. Dort sieht man relativ gut wie die neuen Parameter spezifiert werden.
Hier ist eine Besonderheit, dass wir nun die Bedeutung von Particle types spezifieren können. Außerdem werden auch Partcle types auch von Cluster als Parameter akezeptiert. 