### PR TITLE
Added the ProgressLogger to update the user on progress

### DIFF
--- a/src/analytics/ProgressLogger.cpp
+++ b/src/analytics/ProgressLogger.cpp
@@ -1,0 +1,5 @@
+//
+// Created by Christian Nix on 09.07.24.
+//
+
+#include "ProgressLogger.h"

--- a/src/analytics/ProgressLogger.cpp
+++ b/src/analytics/ProgressLogger.cpp
@@ -1,5 +1,0 @@
-//
-// Created by Christian Nix on 09.07.24.
-//
-
-#include "ProgressLogger.h"

--- a/src/analytics/ProgressLogger.h
+++ b/src/analytics/ProgressLogger.h
@@ -31,7 +31,7 @@ public:
     inline void logProgress(unsigned currentIteration)
     {
         // only log, if new percentage is reached -> 100 updates
-        if (currentIteration < nextLoggingIteration)
+        if (currentIteration < nextLoggingIteration || spdlog::level::info < spdlog::default_logger()->level())
             return;
 
         auto currentTime = std::chrono::steady_clock::now();

--- a/src/analytics/ProgressLogger.h
+++ b/src/analytics/ProgressLogger.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <chrono>
+#include <cmath>
+#include <spdlog/spdlog.h>
+/**
+ * @class ProgressLogger
+ * @brief A class for logging progress during a simulation.
+ */
+class ProgressLogger {
+public:
+    /**
+     * @brief Constructs a ProgressLogger object with the specified start time, end time, and delta
+     * time.
+     * @param startTime The start time of the simulation.
+     * @param endTime The end time of the simulation.
+     * @param deltaT The time steps of the simulation.
+     */
+    ProgressLogger(double startTime, double endTime, double deltaT)
+        : totalIterations(static_cast<unsigned>(std::ceil((endTime - startTime) / deltaT)))
+        , startTime(std::chrono::steady_clock::now())
+        , nextLoggingIteration(totalIterations / 100)
+    {
+    }
+
+    /**
+     * @brief Logs the progress of the simulation. This will only write a log if a new percentage is
+     * reached.
+     * @param currentIteration The current iteration of the simulation.
+     */
+    inline void logProgress(unsigned currentIteration)
+    {
+        // only log, if new percentage is reached -> 100 updates
+        if (currentIteration < nextLoggingIteration)
+            return;
+
+        auto currentTime = std::chrono::steady_clock::now();
+        long elapsedTime =
+            std::chrono::duration_cast<std::chrono::milliseconds>(currentTime - startTime).count();
+        double progress = static_cast<double>(currentIteration) / totalIterations;
+        long estimatedTimeLeft =
+            static_cast<long>((static_cast<double>(elapsedTime) / progress)) - elapsedTime;
+
+        spdlog::info(
+            "Progress: {:.2f}%, Estimated time left (DD:HH:MM:SS): {:02}:{:02}:{:02}:{:02}",
+            progress * 100,
+            estimatedTimeLeft / 86400000l,
+            (estimatedTimeLeft % 86400000l) / 3600000l,
+            (estimatedTimeLeft % 3600000l) / 60000l,
+            (estimatedTimeLeft % 60000l) / 1000l);
+
+        nextLoggingIteration =
+            static_cast<unsigned>(static_cast<double>(totalIterations) * (progress + 0.01));
+    };
+
+private:
+    unsigned totalIterations; /**< The total number of iterations in the simulation. */
+    std::chrono::steady_clock::time_point startTime; /**< The start time of the simulation. */
+    unsigned nextLoggingIteration; /**< Next iteration a log will be added. */
+};

--- a/src/simulation/LennardJonesDomainSimulation.cpp
+++ b/src/simulation/LennardJonesDomainSimulation.cpp
@@ -75,6 +75,7 @@ void LennardJonesDomainSimulation::runSim()
         if (iteration % updateFrequency == 0) {
             cellGrid.updateCells();
         }
+        progressLogger.logProgress(iteration);
         spdlog::trace("Iteration {} finished.", iteration);
 
         time += delta_t;

--- a/src/simulation/MixedLJSimulation.cpp
+++ b/src/simulation/MixedLJSimulation.cpp
@@ -165,13 +165,14 @@ void MixedLJSimulation::runSim()
         if (iteration % updateFrequency == 0) {
             cellGrid.updateCells();
         }
+        // Update thermostat if frequency is positive
         if (n_thermostat && iteration % n_thermostat == 0) {
             thermostat.updateT(this->container);
         }
         if (doProfile) {
             particleUpdates += container.activeParticleCount;
         }
-        // Update thermostat if frequency is positive
+        progressLogger.logProgress(iteration);
         spdlog::trace("Iteration {} finished.", iteration);
 
         time += delta_t;

--- a/src/simulation/baseSimulation.cpp
+++ b/src/simulation/baseSimulation.cpp
@@ -20,6 +20,7 @@ Simulation::Simulation(
     , strategy(strat)
     , writer(std::move(writer))
     , reader(std::move(reader))
+    , progressLogger(time, end_time, delta_t)
 {
 }
 

--- a/src/simulation/baseSimulation.h
+++ b/src/simulation/baseSimulation.h
@@ -1,6 +1,7 @@
 
 #pragma once
 
+#include "analytics/ProgressLogger.h"
 #include "models/ParticleContainer.h"
 #include <memory>
 
@@ -73,4 +74,5 @@ protected:
     PhysicsStrategy& strategy; /**< The strategy which is used to calculate the physics */
     std::unique_ptr<FileWriter> writer; /**< The output writer */
     std::unique_ptr<FileReader> reader; /**< The input reader */
+    ProgressLogger progressLogger; /**< The progress logger */
 };

--- a/src/simulation/lennardJonesSim.cpp
+++ b/src/simulation/lennardJonesSim.cpp
@@ -62,6 +62,7 @@ void LennardJonesSimulation::runSim()
         if (iteration % frequency == 0) {
             writer->plotParticles(*this);
         }
+        progressLogger.logProgress(iteration);
         spdlog::trace("Iteration {} finished.", iteration);
 
         time += delta_t;

--- a/src/simulation/linkedLennardJonesSim.cpp
+++ b/src/simulation/linkedLennardJonesSim.cpp
@@ -56,6 +56,7 @@ void LinkedLennardJonesSimulation::runSim()
         if (iteration % updateFrequency == 0) {
             cellGrid.updateCells();
         }
+        progressLogger.logProgress(iteration);
         spdlog::trace("Iteration {} finished.", iteration);
 
         time += delta_t;

--- a/src/simulation/planetSim.cpp
+++ b/src/simulation/planetSim.cpp
@@ -39,6 +39,7 @@ void PlanetSimulation::runSim()
         if (iteration % frequency == 0) {
             writer->plotParticles(*this);
         }
+        progressLogger.logProgress(iteration);
         spdlog::trace("Iteration: {}", iteration);
 
         time += delta_t;


### PR DESCRIPTION
**Features**

- The Logger gets called in each iteration
- When the progress has increased by 1%, the logger will output the progress and estimated time left
- The logger gets called every iteration and handles outputs by itself (including skips etc.)
- The logger is moved all the way to the base simulation and can simply be called by all other classes